### PR TITLE
Updated the http_request_duration metrics to new api_time version

### DIFF
--- a/grafana/mattermost-performance-kpi-metrics_rev2.json
+++ b/grafana/mattermost-performance-kpi-metrics_rev2.json
@@ -882,17 +882,17 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1000.0 * rate(mattermost_http_request_duration_seconds_sum{instance=~\"$server\"}[1m]) /   rate(mattermost_http_request_duration_seconds_count{instance=~\"$server\"}[1m])",
+          "expr": "1000.0 * rate(mattermost_api_time_sum{instance=~\"$server\"}[1m]) /   rate(mattermost_api_time_count{instance=~\"$server\"}[1m])",
           "format": "time_series",
           "interval": "5s",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}",
-          "metric": "mattermost_http_request_duration_seconds_sum",
+          "metric": "mattermost_api_time_sum",
           "refId": "A",
           "step": 5
         },
         {
-          "expr": "1000.0 * rate(mattermost_http_request_duration_seconds_sum[1m]) /   rate(mattermost_http_request_duration_seconds_count[1m])",
+          "expr": "1000.0 * rate(mattermost_api_time_sum[1m]) /   rate(mattermost_api_time_count[1m])",
           "format": "time_series",
           "hide": true,
           "intervalFactor": 1,

--- a/grafana/mattermost-performance-monitoring_rev2.json
+++ b/grafana/mattermost-performance-monitoring_rev2.json
@@ -1018,12 +1018,12 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "1000.0 * rate(mattermost_http_request_duration_seconds_sum{instance=~\"$server\"}[1m]) /   rate(mattermost_http_request_duration_seconds_count{instance=~\"$server\"}[1m])",
+          "expr": "1000.0 * rate(mattermost_api_time_sum{instance=~\"$server\"}[1m]) /   rate(mattermost_api_time_count{instance=~\"$server\"}[1m])",
           "format": "time_series",
           "interval": "5s",
           "intervalFactor": 1,
           "legendFormat": "{{instance}}",
-          "metric": "mattermost_http_request_duration_seconds_sum",
+          "metric": "mattermost_api_time_sum",
           "refId": "A",
           "step": 5
         }


### PR DESCRIPTION
We made a change to the name of our metrics related to http request duration (see https://mattermost.atlassian.net/browse/MM-25005).

This PR updates the metrics in the grafana dashboards to reflect this change.