### PR TITLE
Update Calls Performance Monitoring dashboard

### DIFF
--- a/grafana/mattermost-calls-performance-monitoring.json
+++ b/grafana/mattermost-calls-performance-monitoring.json
@@ -9,17 +9,17 @@
       "pluginName": "Prometheus"
     },
     {
-      "name": "VAR_RTCD_API_PORT",
+      "name": "VAR_RTCD_METRICS_PORT",
       "type": "constant",
-      "label": "rtcd_api_port",
+      "label": "rtcd_metrics_port",
       "value": "8045",
       "description": ""
     },
     {
-      "name": "VAR_CALLS_API_PORT",
+      "name": "VAR_CALLS_METRICS_PORT",
       "type": "constant",
-      "label": "calls_api_port",
-      "value": "8065",
+      "label": "calls_metrics_port",
+      "value": "8067",
       "description": ""
     }
   ],
@@ -129,7 +129,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "avg(irate(mattermost_plugin_calls_process_cpu_seconds_total{instance=~\"$calls:$calls_api_port\"}[2m])* 100) by (instance)",
+          "expr": "avg(irate(mattermost_plugin_calls_process_cpu_seconds_total{instance=~\"$calls:$calls_metrics_port\"}[2m])* 100) by (instance)",
           "hide": false,
           "legendFormat": "calls - {{ instance }}",
           "range": true,
@@ -141,7 +141,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "avg(irate(rtcd_process_cpu_seconds_total{instance=~\"$rtcd:$rtcd_api_port\"}[2m])* 100) by (instance)",
+          "expr": "avg(irate(rtcd_process_cpu_seconds_total{instance=~\"$rtcd:$rtcd_metrics_port\"}[2m])* 100) by (instance)",
           "hide": false,
           "legendFormat": "rtcd - {{ instance }}",
           "range": true,
@@ -230,7 +230,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "avg(go_memstats_heap_inuse_bytes{instance=~\"$calls:$calls_api_port\"}) by (instance)",
+          "expr": "avg(go_memstats_heap_inuse_bytes{instance=~\"$calls:$calls_metrics_port\"}) by (instance)",
           "legendFormat": "calls - {{ instance }}",
           "range": true,
           "refId": "A"
@@ -241,7 +241,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "avg(go_memstats_heap_inuse_bytes{instance=~\"$rtcd:$rtcd_api_port\"}) by (instance)",
+          "expr": "avg(go_memstats_heap_inuse_bytes{instance=~\"$rtcd:$rtcd_metrics_port\"}) by (instance)",
           "hide": false,
           "legendFormat": "rtcd - {{ instance }}",
           "range": true,
@@ -330,7 +330,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(mattermost_plugin_calls_rtc_sessions_total{instance=~\"$calls:$calls_api_port\"}) by (instance)",
+          "expr": "sum(mattermost_plugin_calls_rtc_sessions_total{instance=~\"$calls:$calls_metrics_port\"}) by (instance)",
           "legendFormat": "calls - {{ instance }}",
           "range": true,
           "refId": "A"
@@ -341,7 +341,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(rtcd_rtc_sessions_total{instance=~\"$rtcd:$rtcd_api_port\"}) by (instance)",
+          "expr": "sum(rtcd_rtc_sessions_total{instance=~\"$rtcd:$rtcd_metrics_port\"}) by (instance)",
           "hide": false,
           "legendFormat": "rtcd - {{ instance }}",
           "range": true,
@@ -430,7 +430,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(go_goroutines{instance=~\"$calls:$calls_api_port\"}) by (instance)",
+          "expr": "sum(go_goroutines{instance=~\"$calls:$calls_metrics_port\"}) by (instance)",
           "hide": false,
           "legendFormat": "calls - {{ instance }}",
           "range": true,
@@ -442,7 +442,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(go_goroutines{instance=~\"$rtcd:$rtcd_api_port\"}) by (instance)",
+          "expr": "sum(go_goroutines{instance=~\"$rtcd:$rtcd_metrics_port\"}) by (instance)",
           "hide": false,
           "legendFormat": "rtcd - {{ instance }}",
           "range": true,
@@ -533,7 +533,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(mattermost_plugin_calls_websocket_events_total{instance=~\"$calls:$calls_api_port\"}[2m])) by (instance, type)",
+          "expr": "sum(rate(mattermost_plugin_calls_websocket_events_total{instance=~\"$calls:$calls_metrics_port\"}[2m])) by (instance, type)",
           "legendFormat": "calls - {{ type }}",
           "range": true,
           "refId": "A"
@@ -654,7 +654,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(rtcd_ws_messages_total{instance=~\"$rtcd:$rtcd_api_port\"}[2m])) by (type, instance)",
+          "expr": "sum(rate(rtcd_ws_messages_total{instance=~\"$rtcd:$rtcd_metrics_port\"}[2m])) by (type, instance)",
           "legendFormat": "rtcd - {{type}} - {{ instance}}",
           "range": true,
           "refId": "A"
@@ -746,7 +746,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "rtcd_ws_connections_total{instance=~\"$rtcd:$rtcd_api_port\"}",
+          "expr": "rtcd_ws_connections_total{instance=~\"$rtcd:$rtcd_metrics_port\"}",
           "legendFormat": "rtcd - {{ instance }}",
           "range": true,
           "refId": "A"
@@ -807,7 +807,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(mattermost_plugin_calls_rtc_errors_total{instance=~\"$calls:$calls_api_port\"}[2m])) by (type, instance)",
+          "expr": "sum(increase(mattermost_plugin_calls_rtc_errors_total{instance=~\"$calls:$calls_metrics_port\"}[2m])) by (type, instance)",
           "hide": false,
           "legendFormat": "calls - {{ type }}",
           "range": true,
@@ -819,7 +819,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(rtcd_rtc_errors_total{instance=~\"$rtcd:$rtcd_api_port\"}[2m])) by (type, instance)",
+          "expr": "sum(increase(rtcd_rtc_errors_total{instance=~\"$rtcd:$rtcd_metrics_port\"}[2m])) by (type, instance)",
           "hide": false,
           "legendFormat": "rtcd - {{ type }}",
           "range": true,
@@ -910,7 +910,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(mattermost_plugin_calls_rtc_conn_states_total{instance=~\"$calls:$calls_api_port\"}[2m])) by (instance, type)",
+          "expr": "sum(increase(mattermost_plugin_calls_rtc_conn_states_total{instance=~\"$calls:$calls_metrics_port\"}[2m])) by (instance, type)",
           "legendFormat": "{{ instance }} - {{ type }}",
           "range": true,
           "refId": "A"
@@ -921,7 +921,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(rtcd_rtc_conn_states_total{instance=~\"$rtcd:$rtcd_api_port\"}[2m])) by (instance, type)",
+          "expr": "sum(increase(rtcd_rtc_conn_states_total{instance=~\"$rtcd:$rtcd_metrics_port\"}[2m])) by (instance, type)",
           "hide": false,
           "legendFormat": "rtcd - {{ instance }} - {{ type }}",
           "range": true,
@@ -1012,7 +1012,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(mattermost_plugin_calls_rtc_rtp_tracks_total{instance=~\"$calls:$calls_api_port\"}) by (instance, direction, type)",
+          "expr": "sum(mattermost_plugin_calls_rtc_rtp_tracks_total{instance=~\"$calls:$calls_metrics_port\"}) by (instance, direction, type)",
           "legendFormat": "{{ instance }} - {{direction}} - {{type}}",
           "range": true,
           "refId": "A"
@@ -1023,7 +1023,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(rtcd_rtc_rtp_tracks_total{instance=~\"$rtcd:$rtcd_api_port\"}) by (instance, direction, type)",
+          "expr": "sum(rtcd_rtc_rtp_tracks_total{instance=~\"$rtcd:$rtcd_metrics_port\"}) by (instance, direction, type)",
           "hide": false,
           "legendFormat": "rtcd - {{ instance }} - {{direction}} - {{type}}",
           "range": true,
@@ -1145,7 +1145,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(mattermost_plugin_calls_store_ops_total{instance=~\"$calls:$calls_api_port\"}[2m])) by (type, instance)",
+          "expr": "sum(rate(mattermost_plugin_calls_store_ops_total{instance=~\"$calls:$calls_metrics_port\"}[2m])) by (type, instance)",
           "legendFormat": "calls - {{ type }} - {{ instance }}",
           "range": true,
           "refId": "A"
@@ -1254,7 +1254,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_plugin_calls_cluster_mutex_grab_time_bucket{instance=~\"$calls:$calls_api_port\"}[2m])) by (group,le))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_plugin_calls_cluster_mutex_grab_time_bucket{instance=~\"$calls:$calls_metrics_port\"}[2m])) by (group,le))",
           "instant": false,
           "legendFormat": "Grab time p99-{{group}}",
           "range": true,
@@ -1266,7 +1266,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "histogram_quantile(0.99, sum(rate(mattermost_plugin_calls_cluster_mutex_locked_time_bucket{instance=~\"$calls:$calls_api_port\"}[2m])) by (group,le))",
+          "expr": "histogram_quantile(0.99, sum(rate(mattermost_plugin_calls_cluster_mutex_locked_time_bucket{instance=~\"$calls:$calls_metrics_port\"}[2m])) by (group,le))",
           "hide": false,
           "instant": false,
           "legendFormat": "Lock time p99-{{group}}",
@@ -1279,7 +1279,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(mattermost_plugin_calls_cluster_mutex_grab_time_sum{instance=~\"$calls:$calls_api_port\"}[2m])) by (group) / sum(rate(mattermost_plugin_calls_cluster_mutex_grab_time_count{instance=~\"$calls:$calls_api_port\"}[2m])) by (group)",
+          "expr": "sum(rate(mattermost_plugin_calls_cluster_mutex_grab_time_sum{instance=~\"$calls:$calls_metrics_port\"}[2m])) by (group) / sum(rate(mattermost_plugin_calls_cluster_mutex_grab_time_count{instance=~\"$calls:$app_metrics_port\"}[2m])) by (group)",
           "hide": false,
           "instant": false,
           "legendFormat": "Grab time avg-{{group}}",
@@ -1292,7 +1292,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(rate(mattermost_plugin_calls_cluster_mutex_locked_time_sum{instance=~\"$calls:$calls_api_port\"}[2m])) by (group) / sum(rate(mattermost_plugin_calls_cluster_mutex_locked_time_count{instance=~\"$calls:$calls_api_port\"}[2m])) by (group)",
+          "expr": "sum(rate(mattermost_plugin_calls_cluster_mutex_locked_time_sum{instance=~\"$calls:$calls_metrics_port\"}[2m])) by (group) / sum(rate(mattermost_plugin_calls_cluster_mutex_locked_time_count{instance=~\"$calls:$app_metrics_port\"}[2m])) by (group)",
           "hide": false,
           "instant": false,
           "legendFormat": "Lock time avg-{{group}}",
@@ -1305,7 +1305,7 @@
             "uid": "${DS_PROMETHEUS_PROD}"
           },
           "editorMode": "code",
-          "expr": "sum(increase(mattermost_plugin_calls_cluster_mutex_lock_retries_total{instance=~\"$calls:$calls_api_port\"}[2m])) by (group)",
+          "expr": "sum(increase(mattermost_plugin_calls_cluster_mutex_lock_retries_total{instance=~\"$calls:$calls_metrics_port\"}[2m])) by (group)",
           "hide": false,
           "instant": false,
           "legendFormat": "Retries {{group}}",
@@ -1801,7 +1801,7 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "(.*):$calls_api_port",
+        "regex": "(.*):$calls_metrics_port",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
@@ -1824,7 +1824,7 @@
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,
-        "regex": "(.*):$rtcd_api_port",
+        "regex": "(.*):$rtcd_metrics_port",
         "skipUrlSync": false,
         "sort": 0,
         "type": "query"
@@ -1832,19 +1832,19 @@
       {
         "hide": 2,
         "label": "",
-        "name": "rtcd_api_port",
-        "query": "${VAR_RTCD_API_PORT}",
+        "name": "rtcd_metrics_port",
+        "query": "${VAR_RTCD_METRICS_PORT}",
         "skipUrlSync": false,
         "type": "constant",
         "current": {
-          "value": "${VAR_RTCD_API_PORT}",
-          "text": "${VAR_RTCD_API_PORT}",
+          "value": "${VAR_RTCD_METRICS_PORT}",
+          "text": "${VAR_RTCD_METRICS_PORT}",
           "selected": false
         },
         "options": [
           {
-            "value": "${VAR_RTCD_API_PORT}",
-            "text": "${VAR_RTCD_API_PORT}",
+            "value": "${VAR_RTCD_METRICS_PORT}",
+            "text": "${VAR_RTCD_METRICS_PORT}",
             "selected": false
           }
         ]
@@ -1852,19 +1852,19 @@
       {
         "hide": 2,
         "label": "",
-        "name": "calls_api_port",
-        "query": "${VAR_CALLS_API_PORT}",
+        "name": "calls_metrics_port",
+        "query": "${VAR_CALLS_METRICS_PORT}",
         "skipUrlSync": false,
         "type": "constant",
         "current": {
-          "value": "${VAR_CALLS_API_PORT}",
-          "text": "${VAR_CALLS_API_PORT}",
+          "value": "${VAR_CALLS_METRICS_PORT}",
+          "text": "${VAR_CALLS_METRICS_PORT}",
           "selected": false
         },
         "options": [
           {
-            "value": "${VAR_CALLS_API_PORT}",
-            "text": "${VAR_CALLS_API_PORT}",
+            "value": "${VAR_CALLS_METRICS_PORT}",
+            "text": "${VAR_CALLS_METRICS_PORT}",
             "selected": false
           }
         ]
@@ -1879,6 +1879,6 @@
   "timezone": "",
   "title": "Mattermost Calls - Performance Monitoring",
   "uid": "nwiOkDP45",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }


### PR DESCRIPTION
#### Summary

Updating the dashboard to default to metrics exposed under the common metrics server listener.
Dashboard is backwards compatible with the original endpoint as long as the right port is configured (`8065` vs `8067`)